### PR TITLE
Multi-selection to remove active songs, track count and more.

### DIFF
--- a/EditSong.cs
+++ b/EditSong.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -78,7 +79,7 @@ namespace GHLCP
                 }
                 if (((XmlElement)video).HasAttribute("musicStartTime"))
                 {
-                    videoStartBox.Value = Convert.ToDecimal(((XmlElement)video).GetAttributeNode("musicStartTime").InnerText);
+                    videoStartBox.Value = Convert.ToDecimal(((XmlElement)video).GetAttributeNode("musicStartTime").InnerText, CultureInfo.InvariantCulture);
                 }
             }
 
@@ -102,29 +103,29 @@ namespace GHLCP
                     enableStagefright.Checked = false;
                     parentSetlistBox.Text = ((XmlElement)stagefright).GetAttributeNode("parentSetlistDisabled").InnerText;
                 }
-                careerStartBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("trackStartTime").InnerText);
-                careerEndBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("trackEndTime").InnerText);
-                quickStartBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("quickplayStartTime").InnerText);
-                quickEndBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("quickplayEndTime").InnerText);
+                careerStartBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("trackStartTime").InnerText, CultureInfo.InvariantCulture);
+                careerEndBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("trackEndTime").InnerText, CultureInfo.InvariantCulture);
+                quickStartBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("quickplayStartTime").InnerText, CultureInfo.InvariantCulture);
+                quickEndBox.Value = Convert.ToDecimal(((XmlElement)stagefright).GetAttributeNode("quickplayEndTime").InnerText, CultureInfo.InvariantCulture);
             }
 
             // Highway shit
             XmlNode highway = document.SelectSingleNode("Track/Highway");
-            speedBBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newbeginner").InnerText);
-            speedEBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("neweasy").InnerText);
-            speedMBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newmedium").InnerText);
-            speedHBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newhard").InnerText);
-            speedXBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newexpert").InnerText);
+            speedBBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newbeginner").InnerText, CultureInfo.InvariantCulture);
+            speedEBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("neweasy").InnerText, CultureInfo.InvariantCulture);
+            speedMBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newmedium").InnerText, CultureInfo.InvariantCulture);
+            speedHBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newhard").InnerText, CultureInfo.InvariantCulture);
+            speedXBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("newexpert").InnerText, CultureInfo.InvariantCulture);
             if (((XmlElement)highway).HasAttribute("highwayOpacityMultiplier"))
             {
-                opacityBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("highwayOpacityMultiplier").InnerText);
+                opacityBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("highwayOpacityMultiplier").InnerText, CultureInfo.InvariantCulture);
             } else
             {
                 opacityBox.Enabled = false;
             }
             if (((XmlElement)highway).HasAttribute("highwayTransparency"))
             {
-                transparencyBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("highwayTransparency").InnerText);
+                transparencyBox.Value = Convert.ToDecimal(((XmlElement)highway).GetAttributeNode("highwayTransparency").InnerText, CultureInfo.InvariantCulture);
             }
             else
             {
@@ -179,18 +180,18 @@ namespace GHLCP
 
             // Highway shit
             XmlNode highway = document.SelectSingleNode("Track/Highway");
-            ((XmlElement)highway).SetAttribute("newbeginner", speedBBox.Value.ToString());
-            ((XmlElement)highway).SetAttribute("neweasy", speedEBox.Value.ToString());
-            ((XmlElement)highway).SetAttribute("newmedium", speedMBox.Value.ToString());
-            ((XmlElement)highway).SetAttribute("newhard", speedHBox.Value.ToString());
-            ((XmlElement)highway).SetAttribute("newexpert", speedXBox.Value.ToString());
+            ((XmlElement)highway).SetAttribute("newbeginner", speedBBox.Value.ToString(CultureInfo.InvariantCulture));
+            ((XmlElement)highway).SetAttribute("neweasy", speedEBox.Value.ToString(CultureInfo.InvariantCulture));
+            ((XmlElement)highway).SetAttribute("newmedium", speedMBox.Value.ToString(CultureInfo.InvariantCulture));
+            ((XmlElement)highway).SetAttribute("newhard", speedHBox.Value.ToString(CultureInfo.InvariantCulture));
+            ((XmlElement)highway).SetAttribute("newexpert", speedXBox.Value.ToString(CultureInfo.InvariantCulture));
             if (opacityBox.Enabled)
             {
-                ((XmlElement)highway).SetAttribute("highwayOpacityMultiplier", opacityBox.Value.ToString());
+                ((XmlElement)highway).SetAttribute("highwayOpacityMultiplier", opacityBox.Value.ToString(CultureInfo.InvariantCulture));
             }
             if (transparencyBox.Enabled)
             {
-                ((XmlElement)highway).SetAttribute("highwayTransparency", transparencyBox.Value.ToString());
+                ((XmlElement)highway).SetAttribute("highwayTransparency", transparencyBox.Value.ToString(CultureInfo.InvariantCulture));
             }
             
             // Video shit
@@ -200,14 +201,14 @@ namespace GHLCP
                 if (videoEnabledCheck.Checked) {
                     XmlElement videoelement = document.CreateElement("Video");
                     videoelement.SetAttribute("hasVideo", boolToXml(videoEnabledCheck.Checked));
-                    videoelement.SetAttribute("musicStartTime", videoStartBox.Value.ToString());
+                    videoelement.SetAttribute("musicStartTime", videoStartBox.Value.ToString(CultureInfo.InvariantCulture));
                     trackconfig.AppendChild(videoelement);
                 }
             }
             else
             {
                 ((XmlElement)video).SetAttribute("hasVideo", boolToXml(videoEnabledCheck.Checked));
-                ((XmlElement)video).SetAttribute("musicStartTime", videoStartBox.Value.ToString());
+                ((XmlElement)video).SetAttribute("musicStartTime", videoStartBox.Value.ToString(CultureInfo.InvariantCulture));
             }
 
             // Stagefright shit
@@ -218,10 +219,10 @@ namespace GHLCP
                 {
                     XmlElement stageelement = document.CreateElement("Stagefright");
                     stageelement.SetAttribute("parentSetlist", parentSetlistBox.Text);
-                    stageelement.SetAttribute("trackStartTime", careerStartBox.Value.ToString());
-                    stageelement.SetAttribute("trackEndTime", careerEndBox.Value.ToString());
-                    stageelement.SetAttribute("quickplayStartTime", quickStartBox.Value.ToString());
-                    stageelement.SetAttribute("quickplayEndTime", quickEndBox.Value.ToString());
+                    stageelement.SetAttribute("trackStartTime", careerStartBox.Value.ToString(CultureInfo.InvariantCulture));
+                    stageelement.SetAttribute("trackEndTime", careerEndBox.Value.ToString(CultureInfo.InvariantCulture));
+                    stageelement.SetAttribute("quickplayStartTime", quickStartBox.Value.ToString(CultureInfo.InvariantCulture));
+                    stageelement.SetAttribute("quickplayEndTime", quickEndBox.Value.ToString(CultureInfo.InvariantCulture));
                     trackconfig.AppendChild(stageelement);
                 }
             }
@@ -239,10 +240,10 @@ namespace GHLCP
                         ((XmlElement)stagefright).RemoveAttribute("parentSetlist");
                         ((XmlElement)stagefright).SetAttribute("parentSetlistDisabled", parentSetlistBox.Text);
                     }
-                    ((XmlElement)stagefright).SetAttribute("trackStartTime", careerStartBox.Value.ToString());
-                    ((XmlElement)stagefright).SetAttribute("trackEndTime", careerEndBox.Value.ToString());
-                    ((XmlElement)stagefright).SetAttribute("quickplayStartTime", quickStartBox.Value.ToString());
-                    ((XmlElement)stagefright).SetAttribute("quickplayEndTime", quickEndBox.Value.ToString());
+                    ((XmlElement)stagefright).SetAttribute("trackStartTime", careerStartBox.Value.ToString(CultureInfo.InvariantCulture));
+                    ((XmlElement)stagefright).SetAttribute("trackEndTime", careerEndBox.Value.ToString(CultureInfo.InvariantCulture));
+                    ((XmlElement)stagefright).SetAttribute("quickplayStartTime", quickStartBox.Value.ToString(CultureInfo.InvariantCulture));
+                    ((XmlElement)stagefright).SetAttribute("quickplayEndTime", quickEndBox.Value.ToString(CultureInfo.InvariantCulture));
                 }
             }
             

--- a/MainWindow.Designer.cs
+++ b/MainWindow.Designer.cs
@@ -28,6 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
             this.GameFinderDialog = new System.Windows.Forms.OpenFileDialog();
             this.installedListView = new System.Windows.Forms.ListView();
@@ -48,6 +49,8 @@
             this.columnHeader2 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader3 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader4 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.contextMenuStripActiveList = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.removeFromQuickplayToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.activeControls = new System.Windows.Forms.Panel();
             this.exportCSVButton = new System.Windows.Forms.Button();
             this.activeRemove = new System.Windows.Forms.Button();
@@ -102,10 +105,12 @@
             this.fuckYouActivision = new System.Windows.Forms.ToolStripMenuItem();
             this.ImportSongDialog = new System.Windows.Forms.OpenFileDialog();
             this.saveCSVDialog = new System.Windows.Forms.SaveFileDialog();
+            this.trackCountLabel = new System.Windows.Forms.Label();
             this.songTabs.SuspendLayout();
             this.installedTracks.SuspendLayout();
             this.installedControls.SuspendLayout();
             this.activeTracks.SuspendLayout();
+            this.contextMenuStripActiveList.SuspendLayout();
             this.activeControls.SuspendLayout();
             this.gameHacks.SuspendLayout();
             this.batchHyperspeed.SuspendLayout();
@@ -272,10 +277,10 @@
             this.columnHeader2,
             this.columnHeader3,
             this.columnHeader4});
+            this.activeListView.ContextMenuStrip = this.contextMenuStripActiveList;
             this.activeListView.FullRowSelect = true;
             this.activeListView.HideSelection = false;
             this.activeListView.Location = new System.Drawing.Point(6, 6);
-            this.activeListView.MultiSelect = false;
             this.activeListView.Name = "activeListView";
             this.activeListView.ShowGroups = false;
             this.activeListView.Size = new System.Drawing.Size(524, 453);
@@ -302,8 +307,23 @@
             // 
             this.columnHeader4.Text = "Intensity";
             // 
+            // contextMenuStripActiveList
+            // 
+            this.contextMenuStripActiveList.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.removeFromQuickplayToolStripMenuItem});
+            this.contextMenuStripActiveList.Name = "contextMenuStripActiveList";
+            this.contextMenuStripActiveList.Size = new System.Drawing.Size(203, 26);
+            // 
+            // removeFromQuickplayToolStripMenuItem
+            // 
+            this.removeFromQuickplayToolStripMenuItem.Name = "removeFromQuickplayToolStripMenuItem";
+            this.removeFromQuickplayToolStripMenuItem.Size = new System.Drawing.Size(202, 22);
+            this.removeFromQuickplayToolStripMenuItem.Text = "Remove from Quickplay";
+            this.removeFromQuickplayToolStripMenuItem.Click += new System.EventHandler(this.activeRemove_Click);
+            // 
             // activeControls
             // 
+            this.activeControls.Controls.Add(this.trackCountLabel);
             this.activeControls.Controls.Add(this.exportCSVButton);
             this.activeControls.Controls.Add(this.activeRemove);
             this.activeControls.Controls.Add(this.activeRefresh);
@@ -748,14 +768,16 @@
             // buildXMLItem
             // 
             this.buildXMLItem.Name = "buildXMLItem";
-            this.buildXMLItem.Size = new System.Drawing.Size(204, 22);
+            this.buildXMLItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.B)));
+            this.buildXMLItem.Size = new System.Drawing.Size(246, 22);
             this.buildXMLItem.Text = "Build Setlists/Tracklisting";
             this.buildXMLItem.Click += new System.EventHandler(this.buildXMLItem_Click);
             // 
             // saveModsItem
             // 
             this.saveModsItem.Name = "saveModsItem";
-            this.saveModsItem.Size = new System.Drawing.Size(204, 22);
+            this.saveModsItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
+            this.saveModsItem.Size = new System.Drawing.Size(246, 22);
             this.saveModsItem.Text = "Save Modifications";
             this.saveModsItem.Click += new System.EventHandler(this.saveModsItem_Click);
             // 
@@ -860,6 +882,15 @@
             this.saveCSVDialog.Filter = "CSV file|*.csv|All files|*.*";
             this.saveCSVDialog.Title = "Export Songlist CSV";
             // 
+            // trackCountLabel
+            // 
+            this.trackCountLabel.AutoSize = true;
+            this.trackCountLabel.Location = new System.Drawing.Point(143, 8);
+            this.trackCountLabel.Name = "trackCountLabel";
+            this.trackCountLabel.Size = new System.Drawing.Size(71, 13);
+            this.trackCountLabel.TabIndex = 5;
+            this.trackCountLabel.Text = "Track count: ";
+            // 
             // MainWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -876,7 +907,9 @@
             this.installedTracks.ResumeLayout(false);
             this.installedControls.ResumeLayout(false);
             this.activeTracks.ResumeLayout(false);
+            this.contextMenuStripActiveList.ResumeLayout(false);
             this.activeControls.ResumeLayout(false);
+            this.activeControls.PerformLayout();
             this.gameHacks.ResumeLayout(false);
             this.gameHacks.PerformLayout();
             this.batchHyperspeed.ResumeLayout(false);
@@ -978,6 +1011,9 @@
         private System.Windows.Forms.ToolStripMenuItem disableAllVideosItem;
         private System.Windows.Forms.ToolStripMenuItem enableCustomVIdeosToolStripMenuItem;
         private System.Windows.Forms.CheckBox noteStreakFix;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripActiveList;
+        private System.Windows.Forms.ToolStripMenuItem removeFromQuickplayToolStripMenuItem;
+        private System.Windows.Forms.Label trackCountLabel;
     }
 }
 

--- a/MainWindow.cs
+++ b/MainWindow.cs
@@ -91,6 +91,7 @@ namespace GHLCP
             activeListView.Sorting = SortOrder.Ascending;
             activeListView.ListViewItemSorter = null;
             activeListView.ColumnClick += ListView_ColumnClick;
+            trackCountLabel.Text = "Track count:" + activeListView.Items.Count + "/" + installedListView.Items.Count;
         }
 
         private void ListView_ColumnClick(object o, ColumnClickEventArgs e)
@@ -334,21 +335,33 @@ namespace GHLCP
 
         private void activeListView_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (activeListView.SelectedIndices.Count == 0)
+            switch (activeListView.SelectedIndices.Count) 
             {
-                activeRemove.Enabled = false;
-                activeEdit.Enabled = false;
-            }
-            else
-            {
-                activeRemove.Enabled = true;
-                activeEdit.Enabled = true;
+                case 0:
+                    activeRemove.Enabled = false;
+                    activeEdit.Enabled = false; 
+                    removeFromQuickplayToolStripMenuItem.Enabled = false;
+                    break;
+
+                case 1:
+                    activeRemove.Enabled = true; 
+                    activeEdit.Enabled = true;
+                    removeFromQuickplayToolStripMenuItem.Enabled = true;
+                    break;
+
+                default:
+                    activeRemove.Enabled = true;
+                    activeEdit.Enabled = false;
+                    removeFromQuickplayToolStripMenuItem.Enabled = true;
+                    break;
             }
         }
 
         private void activeRemove_Click(object sender, EventArgs e)
         {
-            activeListView.SelectedItems[0].Remove();
+            foreach (ListViewItem item in activeListView.SelectedItems)
+                item.Remove();
+            trackCountLabel.Text = "Track count:" + activeListView.Items.Count + "/" + installedListView.Items.Count;
         }
 
         private void installedSetActive_Click(object sender, EventArgs e)
@@ -386,6 +399,7 @@ namespace GHLCP
                     }
                 }
             }
+            trackCountLabel.Text = "Track count:" + activeListView.Items.Count + "/" + installedListView.Items.Count;
         }
 
         private void activeRefresh_Click(object sender, EventArgs e)
@@ -519,6 +533,8 @@ namespace GHLCP
                     File.Delete(gamedir + "\\" + filepath);
                 }
             }
+            PopulateInstalled();
+            trackCountLabel.Text = "Track count:" + activeListView.Items.Count + "/" + installedListView.Items.Count;
         }
 
         private void fuckYouActivision_Click(object sender, EventArgs e)

--- a/MainWindow.resx
+++ b/MainWindow.resx
@@ -120,6 +120,9 @@
   <metadata name="GameFinderDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="contextMenuStripActiveList.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>570, 17</value>
+  </metadata>
   <metadata name="controlStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>170, 17</value>
   </metadata>


### PR DESCRIPTION
Adds multi-selection to remove active songs from Quickplay, track count label and shortcut keys. Fixes an issue where songs removed from the installed list were not showing accordingly. 
Fixes an issue where NumericUpDown controls would generate errors for international users.